### PR TITLE
Delete swap file after asking for permission

### DIFF
--- a/src/memline.c
+++ b/src/memline.c
@@ -1681,6 +1681,8 @@ ml_recover(void)
     }
     else
     {
+	int choice;
+
 	if (curbuf->b_changed)
 	{
 	    msg(_("Recovery completed. You should check if everything is OK."));
@@ -1689,7 +1691,17 @@ ml_recover(void)
 	}
 	else
 	    msg(_("Recovery completed. Buffer contents equals file contents."));
-	msg_puts(_("\nYou may want to delete the .swp file now.\n\n"));
+
+	choice = do_dialog(VIM_QUESTION,
+		NULL,
+		(char_u *)_("Delete the swap file now?"),
+		(char_u *)_("&Yes\n&No"), 1, NULL, FALSE);
+
+	if (choice == 1)
+	{
+		mch_remove(fname_used);
+	}
+
 	cmdline_row = msg_row;
     }
 #ifdef FEAT_CRYPT


### PR DESCRIPTION
When vim crashes and is able to recover edits from a swap file, the swap file is left on the file system. Vim advises to remove it, but this leaves a burden on the user to find and delete the file.

This code change asks the user if the swap file should be deleted. If the user selects that, the swap file is deleted. Fixes #1237 